### PR TITLE
Fixed disabling of yum plugin - fastestmirror

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -25,7 +25,7 @@
           mode=0644
 
   - name: Disable fastest mirror plugin
-    lineinfile: dest=/etc/yum/pluginconf.d/fastestmirror.conf regexp=^enabled line='enabled = 1'
+    lineinfile: dest=/etc/yum/pluginconf.d/fastestmirror.conf regexp=^enabled line='enabled = 0'
 
   - name: Install core packages
     yum: name={{ item }} state=installed


### PR DESCRIPTION
Noticed that enabled bit was set the wrong way.  My vim setup also added the newline at the end of the file when I saved it.
