### PR TITLE
Only enable exec-shield when possible

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -109,6 +109,16 @@
     notify:
        - reload sysctl.conf
 
+  - name: Detect exec-shield
+    action: stat path=/proc/sys/kernel/exec-shield
+    register: exec_shield
+
+  - name: Enable exec-shield
+    lineinfile: dest=/etc/sysctl.conf state=present regexp='^kernel.exec-shield' line='kernel.exec-shield = 1'
+    when: exec_shield.stat.exists == True
+    notify:
+      - reload sysctl.conf
+
   - name: Disable kdump
     service: name=kdump state=stopped enabled=no
     ignore_errors: yes

--- a/roles/base/templates/sysctl.conf.j2
+++ b/roles/base/templates/sysctl.conf.j2
@@ -38,9 +38,6 @@ net.ipv4.conf.all.arp_notify = 1
 # Restrict Core Dumps
 fs.suid_dumpable = 0
 
-#Enable ExecShield
-kernel.exec-shield = 1
-
 # Enable Randomized Virtual Memory Region Placement
 kernel.randomize_va_space = 2
 


### PR DESCRIPTION
Systems that support NX don't have this.
